### PR TITLE
Address Multiple Issues with Lesson

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,27 +1,28 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    coderay (1.1.2)
-    diff-lcs (1.3)
-    method_source (0.9.2)
-    pry (0.12.2)
-      coderay (~> 1.1.0)
-      method_source (~> 0.9.0)
-    rspec (3.8.0)
-      rspec-core (~> 3.8.0)
-      rspec-expectations (~> 3.8.0)
-      rspec-mocks (~> 3.8.0)
-    rspec-core (3.8.0)
-      rspec-support (~> 3.8.0)
-    rspec-expectations (3.8.2)
+    coderay (1.1.3)
+    diff-lcs (1.6.2)
+    method_source (1.1.0)
+    pry (0.15.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    rspec (3.13.1)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.5)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.8.0)
-    rspec-mocks (3.8.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.8.0)
-    rspec-support (3.8.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.4)
 
 PLATFORMS
+  arm64-darwin-24
   ruby
 
 DEPENDENCIES
@@ -29,4 +30,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   2.0.1
+   2.7.0

--- a/bin/tictactoe
+++ b/bin/tictactoe
@@ -1,3 +1,3 @@
 #!/usr/bin/env ruby
 require 'pry'
-require_relative '../lib/tic_tac_toe.rb'
+require './lib/tic_tac_toe'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 require_relative "../lib/tic_tac_toe.rb"
 
 RSpec.configure do |config|
-  config.order = :default
+  config.order = :random
 end
 
 RSpec::Matchers.define :include_array do |expected|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 require_relative "../lib/tic_tac_toe.rb"
 
 RSpec.configure do |config|
-  config.order = :random
+  config.order = :defined
 end
 
 RSpec::Matchers.define :include_array do |expected|


### PR DESCRIPTION
Fixes issues with this lesson that prevent it from running:

1. Regenerate Gemfile.lock with newest version of bundler. 2.0.1 had a deprecated method that would break installation
2. Fix the deprecated :default sorting strategy
3. Why `require_relative` was replaced with `require`:

    When running the CLI specs, the test suite loads `bin/tictactoe` using `eval(File.read(file), binding)`. In this context, Ruby sets `__FILE__` to something like `(eval at ...)` instead of the actual filename. Since `require_relative` depends on `__FILE__` to resolve paths, it fails with a "cannot infer basepath" error.

    Switching to:

    ```ruby
    require './lib/tic_tac_toe'
    ```

    fixes this because [require](http://_vscodecontentref_/0) uses the current working directory, which is set correctly by the test runner, and does not depend on `__FILE__`.

    **Summary:**  
    - [require_relative](http://_vscodecontentref_/1) fails when the file is loaded via [eval](http://_vscodecontentref_/2) in tests.
    - [require './lib/tic_tac_toe'](http://_vscodecontentref_/3) works in both normal execution and test environments.